### PR TITLE
feat(ui): add toggle to switch between list and grid view

### DIFF
--- a/app/src/main/java/com/feny/pokemonjetpack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/feny/pokemonjetpack/ui/theme/Theme.kt
@@ -35,7 +35,7 @@ private val DarkColorScheme = darkColorScheme(
     onSecondary = Color.Black,
     background = Color(0xFF121212),
     onBackground = Color.White,
-    surface = Color(0xFF1E1E1E),
+    surface = Color(0xFFFFEB3B),
     onSurface = Color.White,
 )
 

--- a/app/src/main/java/com/feny/pokemonjetpack/ui/theme/Type.kt
+++ b/app/src/main/java/com/feny/pokemonjetpack/ui/theme/Type.kt
@@ -39,5 +39,10 @@ val Typography = Typography(
     bodyMedium = TextStyle(
         fontFamily = VT323,
         fontSize = 14.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = PressStart2P,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp
     )
 )

--- a/app/src/main/java/com/feny/pokemonjetpack/ui/theme/presentation/pokemonlist/PokemonGridItem.kt
+++ b/app/src/main/java/com/feny/pokemonjetpack/ui/theme/presentation/pokemonlist/PokemonGridItem.kt
@@ -1,0 +1,81 @@
+package com.feny.pokemonjetpack.ui.theme.presentation.pokemonlist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.feny.pokemonjetpack.domain.model.Pokemon
+
+@Composable
+fun PokemonGridItem(
+    pokemon: Pokemon,
+    isLoading: Boolean = false,
+    onClick: (String) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .clickable { if (!isLoading) onClick(pokemon.name) },
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (isLoading) {
+                Box(
+                    modifier = Modifier
+                        .size(72.dp)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceVariant,
+                            CircleShape
+                        )
+                )
+            } else {
+                AsyncImage(
+                    model = pokemon.imageUrl,
+                    contentDescription = pokemon.name,
+                    modifier = Modifier.size(72.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = if (isLoading) "..." else pokemon.name,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/feny/pokemonjetpack/ui/theme/presentation/pokemonlist/PokemonListViewModel.kt
+++ b/app/src/main/java/com/feny/pokemonjetpack/ui/theme/presentation/pokemonlist/PokemonListViewModel.kt
@@ -14,10 +14,17 @@ class PokemonListViewModel(
     private val _state = MutableStateFlow(PokemonListState())
     val state: StateFlow<PokemonListState> = _state
 
+    private val _isGrid = MutableStateFlow(false)
+    val isGrid: StateFlow<Boolean> = _isGrid
+
     private val limit = 20
 
     init {
         loadPokemon(page = 0)
+    }
+
+    fun toggleLayout() {
+        _isGrid.value = !_isGrid.value
     }
 
     private fun loadPokemon(page: Int) {

--- a/app/src/main/res/drawable/ic_grid.xml
+++ b/app/src/main/res/drawable/ic_grid.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/pokemon_background" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@color/pokemon_background" android:fillType="evenOdd" android:pathData="M3,3v8h8L11,3L3,3zM9,9L5,9L5,5h4v4zM3,13v8h8v-8L3,13zM9,19L5,19v-4h4v4zM13,3v8h8L21,3h-8zM19,9h-4L15,5h4v4zM13,13v8h8v-8h-8zM19,19h-4v-4h4v4z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_list.xml
+++ b/app/src/main/res/drawable/ic_list.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="@color/pokemon_background" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@color/pokemon_background" android:pathData="M3,13h2v-2L3,11v2zM3,17h2v-2L3,15v2zM3,9h2L5,7L3,7v2zM7,13h14v-2L7,11v2zM7,17h14v-2L7,15v2zM7,7v2h14L21,7L7,7z"/>
+    
+</vector>


### PR DESCRIPTION
✨ Feature: Switch between List and Grid Layout
This PR introduces a new feature that allows users to toggle between list view and grid view when browsing Pokémon.
🔄 Changes Made
Added IconButton in the Pokémon list screen to switch between list mode and grid mode.
Implemented Grid layout using LazyVerticalGrid.
Refactored UI:
Extracted PokemonListItem (list view) into a separate composable file.
Extracted PokemonGridItem (grid view) into a separate composable file.
Ensured smooth endless scrolling works in both list and grid modes.
🛠️ Tech Stack
Jetpack Compose for UI.
Material 3 IconButton with dynamic icon switching (List ↔ Grid).
✅ Test Cases
Toggle button switches layout correctly.
Endless scroll works in both views.
Search and detail navigation remain functional.
🎯 Why
This feature improves user experience by providing flexibility to view Pokémon in either a compact grid mode or a detailed list mode.